### PR TITLE
Add heatmap mode

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -77,6 +77,13 @@ class App extends Component {
       showTowers: !!showTowers,
     });
   };
+  
+  handleTowerTypeToggle = (towerType) => {
+    this.setState({
+      showTestCenters: !!towerType,
+      showTowers: !!towerType
+    })
+  }
 
   toggleLeftNav = () => {
     this.setState({
@@ -131,7 +138,7 @@ class App extends Component {
                     <IndiaData
                       indiaData={indiaData}
                       onStateSelect={this.handleStateSelect}
-                      onTestCenterToggle={this.handleTestCenterToggle}
+                      onTowerToggle={this.handleTowerTypeToggle}
                       viewTestCenters={showTestCenters}
                       viewLTE={showLTE}
                       handleStateReset={this.handleStateReset}

--- a/src/components/TowersFunctional.js
+++ b/src/components/TowersFunctional.js
@@ -145,6 +145,7 @@ function Towers(props) {
   // let zoom = 4;
   const { viewTowers } = props;
   if (viewTowers) {
+    // Show tower data
     Mapdata.push(
       {
         lon: data.lte[4],
@@ -171,6 +172,16 @@ function Towers(props) {
         text: data.umts[7],
       }
     );
+  } else {
+    // Show heatmap data
+    Mapdata.push(
+      {
+        lon: data.lte[4],
+        lat: data.lte[5],
+        type: 'densitymapbox',
+        z: data.lte[2]
+      }
+    )
   }
 
   if (props.viewTestCenters) {

--- a/src/components/stateWiseList/IndiaData.js
+++ b/src/components/stateWiseList/IndiaData.js
@@ -7,7 +7,7 @@ import Dropdown from '../stateListDropdown';
 const cx = classNames.bind(require('./stateWiseList.module.css'));
 
 export default function IndiaData(props) {
-  const { onStateSelect, handleStateReset } = props;
+  const { onStateSelect, handleStateReset, onTowerToggle, viewTestCenters } = props;
 
   const handleTestClick = (center) => {
     const selectedState = testCenter.find((location) => {
@@ -20,6 +20,13 @@ export default function IndiaData(props) {
   };
   return (
     <>
+      <div>
+        <button onClick={() => onTowerToggle(!viewTestCenters)}>
+        {
+          viewTestCenters ? "Show Heatmap" : "Show Towers"
+        }
+        </button>
+      </div>
       <section className={cx('list-wrapper')}>
         <section className={cx('list-content')}>
           <Dropdown


### PR DESCRIPTION
This commit adds a heat map to the existing map. The current method for doing so swaps map data without reloading the full map. Giving good performance as well as good visualization.
The current data being plotted is the lte towers (with the NET attribute as the value). This needs to be replaced with the actual data